### PR TITLE
(PDB-5338) Strip unrecognized keys from catalog resources

### DIFF
--- a/src/puppetlabs/puppetdb/catalogs.clj
+++ b/src/puppetlabs/puppetdb/catalogs.clj
@@ -88,6 +88,7 @@
   (:require [clojure.core.match :refer [match]]
             [clojure.set :as set]
             [clojure.string :as string]
+            [clojure.tools.logging :as log]
             [puppetlabs.puppetdb.cheshire :as json]
             [puppetlabs.puppetdb.schema :as pls]
             [puppetlabs.puppetdb.time :refer [to-timestamp]]
@@ -273,13 +274,32 @@
 
 ;; ## Resource normalization
 
+;; the kind field was added to improve agent/server communication, so resources
+;; are expected to have it, but we do not store it. Other unrecognized keys will
+;; be added to it so that each unrecognized key is only logged once per startup.
+(def already-seen-unrecognized-keys (atom #{:kind}))
+
+(defn- strip-unknown-attributes
+  "Removes unknown attributes from a resource. This is essential for the forward compatibility
+  of PuppetDB when the puppet agent makes additions to its resource definition."
+  [{:keys [type title] :as resource} expected-keys already-seen-unrecognized-keys]
+  (let [unrecognized-keys (set/difference (set (keys resource))
+                                          expected-keys
+                                          @already-seen-unrecognized-keys)]
+    (when-let [ks (seq unrecognized-keys)]
+      (log/warn (trs "Ignoring unrecognized catalog resource key(s) {0}. Future warnings will be surpressed."
+                     ks type title))
+      (swap! already-seen-unrecognized-keys set/union unrecognized-keys))
+    (select-keys resource expected-keys)))
+
 (defn transform-resource*
-  "Normalizes the structure of a single `resource`. Right now this just means
-  setifying the tags."
-  [resource]
+  "Normalizes the structure of a single `resource`."
+  [resource expected-keys already-seen-unrecognized-keys]
   {:pre [(map? resource)]
    :post [(set? (:tags %))]}
-  (transform-tags resource))
+  (-> resource
+      transform-tags
+      (strip-unknown-attributes expected-keys already-seen-unrecognized-keys)))
 
 (defn transform-resources
   "Turns the list of resources into a mapping of
@@ -289,9 +309,13 @@
           (not (map? resources))]
    :post [(map? (:resources %))
           (= (count resources) (count (:resources %)))]}
-  (let [new-resources (into {} (for [{:keys [type title] :as resource} resources
+  (let [already-seen-unrecognized-keys already-seen-unrecognized-keys
+        expected-keys #{:type :title :exported :file :line :tags :aliases :parameters}
+        new-resources (into {} (for [{:keys [type title] :as resource} resources
                                      :let [resource-spec    {:type type :title title}
-                                           new-resource     (transform-resource* resource)]]
+                                           new-resource     (transform-resource* resource
+                                                                                 expected-keys
+                                                                                 already-seen-unrecognized-keys)]]
                                  [resource-spec new-resource]))]
     (assoc catalog :resources new-resources)))
 

--- a/test/puppetlabs/puppetdb/catalogs_test.clj
+++ b/test/puppetlabs/puppetdb/catalogs_test.clj
@@ -120,19 +120,21 @@
                               :parameters {:ensure "present"
                                            :user   "root"
                                            :group  "root"
-                                           :source "puppet:///foobar/foo/bar"}}]}]
+                                           :source "puppet:///foobar/foo/bar"}}]}
+        normalized-catalog {:resources {{:type "File" :title "/etc/foobar"}
+                                        {:type       "File"
+                                         :title      "/etc/foobar"
+                                         :exported   false
+                                         :line       1234
+                                         :file       "/tmp/foobar.pp"
+                                         :tags       #{"class" "foobar"}
+                                         :parameters {:ensure "present"
+                                                      :user   "root"
+                                                      :group  "root"
+                                                      :source "puppet:///foobar/foo/bar"}}}}]
     (is (= (-> catalog
                (transform-resources))
-           {:resources {{:type "File" :title "/etc/foobar"} {:type       "File"
-                                                             :title      "/etc/foobar"
-                                                             :exported   false
-                                                             :line       1234
-                                                             :file       "/tmp/foobar.pp"
-                                                             :tags       #{"class" "foobar"}
-                                                             :parameters {:ensure "present"
-                                                                          :user   "root"
-                                                                          :group  "root"
-                                                                          :source "puppet:///foobar/foo/bar"}}}}))
+           normalized-catalog))
 
     (let [resources (:resources catalog)
           new-resources (conj resources (first resources))
@@ -147,7 +149,15 @@
       ;; missing resources aren't allowed
       (is (thrown? AssertionError (transform-resources {})))
       ;; pre-created resource maps aren't allow
-      (is (thrown? AssertionError (transform-resources {:resources {}}))))))
+      (is (thrown? AssertionError (transform-resources {:resources {}}))))
+
+    (testing "kind attribute and other unrecognized keys are removed from resources"
+      (let [catalog (update catalog :resources (partial map
+                                                        #(assoc %
+                                                                :kind "unknown"
+                                                                :unknown-key "new resource attribute")))]
+        (is (= (transform-resources catalog)
+               normalized-catalog))))))
 
 (deftest test-v9-conversion
   (testing "v8->v9"

--- a/test/puppetlabs/puppetdb/examples.clj
+++ b/test/puppetlabs/puppetdb/examples.clj
@@ -114,22 +114,26 @@
      :title      "Settings"
      :parameters {}
      :tags       ["class" "settings"]
-     :type       "Class"}
+     :type       "Class"
+     :kind       "unknown"}
     {:exported   false
      :title      "main"
      :parameters {:name "main"}
      :tags       ["class"]
-     :type       "Class"}
+     :type       "Class"
+     :kind       "unknown"}
     {:exported   false
      :title      "main"
      :parameters {:name "main"}
      :tags       ["stage"]
-     :type       "Stage"}
+     :type       "Stage"
+     :kind       "unknown"}
     {:exported   false
      :title      "default"
      :parameters {}
      :tags       ["node" "default" "class"]
-     :type       "Node"}]
+     :type       "Node"
+     :kind       "unknown"}]
    :version          "1332533763"
    :transaction_uuid "68b08e2a-eeb1-4322-b241-bfdf151d294b"
    :catalog_uuid "68b08e2a-eeb1-4322-b241-bfdf151d294b"
@@ -163,6 +167,7 @@
                                    :exported false
                                    :file "/tmp/foo"
                                    :line 10
+                                   :kind "unknown"
                                    :tags ["file" "class" "foobar"]
                                    :parameters {:ensure "directory"
                                                 :group  "root"
@@ -178,6 +183,7 @@
                                    :exported false
                                    :file "/tmp/foo"
                                    :line 10
+                                   :kind "unknown"
                                    :tags ["file" "class" "foobar"]
                                    :parameters {:ensure "directory"
                                                 :group  "root"
@@ -191,6 +197,7 @@
                                    :exported false
                                    :file "/tmp/foo"
                                    :line 10
+                                   :kind "unknown"
                                    :tags ["file" "class" "foobar"]
                                    :parameters {:ensure "directory"
                                                 :group  "root"

--- a/test/puppetlabs/puppetdb/generative/generators.clj
+++ b/test/puppetlabs/puppetdb/generative/generators.clj
@@ -58,6 +58,7 @@
 (defgen :resource/exported gen/boolean)
 (defgen :resource/file (string+ 1024))
 (defgen :resource/line pg-pos-integer)
+(defgen :resource/kind (string+ 15))
 
 (defgen :resource/tag  (gen/string-from-regex #"[a-z0-9_][a-z0-9_:\-.]*"))
 (defgen :resource/tags (gen/vector :resource/tag 0 3))
@@ -78,6 +79,7 @@
                                     :resource/exported
                                     :resource/file
                                     :resource/line
+                                    :resource/kind
                                     :resource/parameters
                                     :resource/tags))
 

--- a/test/puppetlabs/puppetdb/testutils/catalogs.clj
+++ b/test/puppetlabs/puppetdb/testutils/catalogs.clj
@@ -44,7 +44,10 @@
       clojure.walk/stringify-keys
       (dissoc "hash")
       (update "producer_timestamp" to-string)
-      (update "resources" (fn [resources] (set (map #(update % "tags" set) resources))))
+      (update "resources" (fn [resources] (->> resources
+                                               (map #(update % "tags" set))
+                                               (map #(dissoc % "kind"))
+                                               set)))
       (update "edges" (fn [edges] (set (map #(update % "relationship" name) edges))))
       ;; In our terminus code, the version is sometimes being serialized as a JSON
       ;;  integer, rather than a string.  The correct data type is String.


### PR DESCRIPTION
Previously, if the agent wanted to add a new catalog resource attribute, current and past versions of PuppetDB would fail to store the new catalog due to the unexpected field. This could cause tight coupling of Puppet Agent and PuppetDB versions in a non-major release, which is undesirable.

To enable the agent to add the resource kind field, as well as future resource fields without breaking PuppetDB, we need to strip the unknown attributes from a catalog's resources because we do not currently have a column to store them in.

For new resource attributes added in the future, PuppetDB will log one warning message per-startup for any keys it does not recognize.